### PR TITLE
Hotfix: regex

### DIFF
--- a/__tests__/__snapshots__/markdown-generator.test.ts.snap
+++ b/__tests__/__snapshots__/markdown-generator.test.ts.snap
@@ -81,7 +81,9 @@ exports[`Emphasis italic using asterisks 1`] = `"*Some text*"`;
 
 exports[`Emphasis italic using underscores 1`] = `"_Some text_"`;
 
-exports[`Escape string 1`] = `"\\\\[Google\\\\]\\\\(https://google\\\\.com/\\\\)"`;
+exports[`Escape string Escape symbols 1`] = `" \\\\\` \\\\* \\\\_ \\\\{ \\\\} \\\\[ \\\\] \\\\( \\\\) \\\\# \\\\+ \\\\- \\\\. \\\\! \\\\|"`;
+
+exports[`Escape string Escape url 1`] = `"\\\\[Google\\\\]\\\\(https://google\\\\.com/\\\\)"`;
 
 exports[`Header Working example 1`] = `"# Some text"`;
 

--- a/__tests__/markdown-generator.test.ts
+++ b/__tests__/markdown-generator.test.ts
@@ -414,8 +414,16 @@ describe("Horizontal rule", () => {
     });
 });
 
-it("Escape string", () => {
-    const textToEscape = MarkdownGenerator.Link("Google", "https://google.com/");
-    const result = MarkdownGenerator.EscapeString(textToEscape);
-    expect(result).toMatchSnapshot();
+describe("Escape string", () => {
+    it("Escape url", () => {
+        const textToEscape = MarkdownGenerator.Link("Google", "https://google.com/");
+        const result = MarkdownGenerator.EscapeString(textToEscape);
+        expect(result).toMatchSnapshot();
+    });
+
+    it("Escape symbols", () => {
+        const textToEscape = "\ ` * _ { } [ ] ( ) # + - . ! |";
+        const result = MarkdownGenerator.EscapeString(textToEscape);
+        expect(result).toMatchSnapshot();
+    });
 });

--- a/src/markdown-generator.ts
+++ b/src/markdown-generator.ts
@@ -236,6 +236,6 @@ export namespace MarkdownGenerator {
      * @see https://daringfireball.net/projects/markdown/syntax#backslash
      */
     export function EscapeString(text: string): string {
-        return text.replace(/[\\\`\*\_\{\}\[\]\(\)\#\+\-\.\!]/g, "\\$&");
+        return text.replace(/[\\\`\*\_\{\}\[\]\(\)\#\+\-\.\!\|]/g, "\\$&");
     }
 }


### PR DESCRIPTION
`|` character added to MarkdownGenerator EscapeString function regex.